### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/electron": "1.4.32",
     "@types/fullcalendar": "2.7.37",
     "@types/hammerjs": "2.0.34",
-    "@types/jquery ": "2.0.40",
+    "@types/jquery": "2.0.40",
     "@types/jquery.slimscroll": "1.3.30",
     "@types/lodash": "ts2.0",
     "@types/node": "6.0.63",


### PR DESCRIPTION
Trailing space was giving error while "npm install"

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
compiling issue due to trailing space removed.


* **What is the new behavior (if this is a feature change)?**
npm install will work successfully


* **Other information**:
